### PR TITLE
fix: harden tray startup and release asset naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 CtyunHelper 是一个面向 Windows 的天翼云电脑助手，提供自动保活、积分任务、AI 任务和积分商品自动兑换等功能。
 
-程序为单文件 `CtyunHelper.exe`，下载后即可运行，不需要安装 Docker、Python、Chromium、.NET 或其他运行环境。
+程序为单文件 `CtyunHelper-v<版本号>.exe`，下载后即可运行，不需要安装 Docker、Python、Chromium、.NET 或其他运行环境。
 
 ## 下载
 
 前往 [Releases](https://github.com/uvwt/CtyunHelper/releases) 下载最新版本：
 
-- Windows：`CtyunHelper.exe`
+- Windows：`CtyunHelper-v<版本号>.exe`
 
 下载后双击运行即可。建议始终从本仓库 Release 页面获取程序。
 
@@ -139,7 +139,7 @@ CtyunHelper 可以自动执行“与AI对话1次”积分任务，也可以通�
 
 ## 更新
 
-下载新版 `CtyunHelper.exe` 后退出旧版本，再用新版文件替换即可。用户配置、登录凭据和运行状态保存在 Windows 用户目录中，不会因为替换 EXE 自动丢失。
+下载新版 `CtyunHelper-v<版本号>.exe` 后退出旧版本，再运行新版文件即可。用户配置、登录凭据和运行状态保存在 Windows 用户目录中，不会因为替换 EXE 自动丢失。
 
 当前版本：**0.1.3**
 
@@ -149,11 +149,10 @@ Windows 界面使用 `github.com/tailscale/walk`，核心业务仍保持在 Go �
 
 ```powershell
 go test ./...
-go build -ldflags "-H=windowsgui" -o CtyunHelper.exe ./cmd/ctyun-helper
-powershell -ExecutionPolicy Bypass -File .\scripts\embed-icon-windows.ps1 -Executable .\CtyunHelper.exe
+powershell -ExecutionPolicy Bypass -File .\scripts\build-release-windows.ps1
 ```
 
-最后一步会把应用图标、Common Controls v6 和 Per-Monitor V2 DPI manifest 直接写入 EXE；最终仍为单文件程序，不需要额外运行时 DLL。
+发布构建脚本会读取 `internal/buildinfo` 中的版本号，生成 `dist\CtyunHelper-v<版本号>.exe`，并把应用图标、Common Controls v6 和 Per-Monitor V2 DPI manifest 直接写入 EXE；最终仍为单文件程序，不需要额外运行时 DLL。
 
 ## 项目
 

--- a/internal/winui/walk_main_windows.go
+++ b/internal/winui/walk_main_windows.go
@@ -5,6 +5,7 @@ package winui
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 
 	"github.com/tailscale/walk"
@@ -15,6 +16,15 @@ import (
 )
 
 const walkWindowTitle = "天翼云电脑助手"
+
+// 固定 GUID 让 Windows Shell 按应用身份管理托盘图标，避免 Walk 默认的
+// (HWND, ID) 路径在部分 Shell 环境中因 ID 冲突导致 Shell_NotifyIcon(NIM_ADD) 失败。
+var ctyunHelperTrayGUID = windows.GUID{
+	Data1: 0x9127994e,
+	Data2: 0x5e0d,
+	Data3: 0x45a8,
+	Data4: [8]byte{0x9e, 0xf3, 0x44, 0xdf, 0xa0, 0xf0, 0xd1, 0xd2},
+}
 
 type walkMainView struct {
 	runtime *app.Runtime
@@ -48,6 +58,7 @@ type walkMainView struct {
 
 	mu       sync.Mutex
 	quitting bool
+	trayErr  error
 }
 
 func Run(buildRuntime func() (*app.Runtime, error), options RunOptions) error {
@@ -97,12 +108,25 @@ func Run(buildRuntime func() (*app.Runtime, error), options RunOptions) error {
 	}()
 
 	view.applyState(view.model.Snapshot())
-	if !options.StartHidden {
+	if shouldShowMainWindow(options.StartHidden, view.tray != nil) {
 		view.window.Show()
+	}
+	if view.trayErr != nil {
+		fmt.Fprintf(os.Stderr, "winui: system tray unavailable: %v\n", view.trayErr)
+		walk.MsgBox(
+			view.window,
+			"系统托盘不可用",
+			"系统托盘初始化失败，程序已切换为普通窗口模式。关闭主窗口将退出程序。",
+			walk.MsgBoxIconWarning|walk.MsgBoxOK,
+		)
 	}
 
 	walkApp.Run()
 	return nil
+}
+
+func shouldShowMainWindow(startHidden, trayAvailable bool) bool {
+	return !startHidden || !trayAvailable
 }
 
 func (v *walkMainView) create() error {
@@ -208,6 +232,13 @@ func (v *walkMainView) create() error {
 		_ = v.window.SetIcon(icon)
 	}
 
+	if err := v.createTray(); err != nil {
+		// 托盘只是交互入口，不应成为保活和自动任务的启动前置条件。
+		// 托盘不可用时保留 MainWindow 默认关闭行为，让用户仍能正常退出程序。
+		v.trayErr = err
+		return nil
+	}
+
 	// MainWindow 默认会在收到 WM_CLOSE 后调用 Application.Exit，即便 Closing
 	// handler 已取消关闭。托盘应用必须关闭这个默认行为，真正退出只走托盘“退出”。
 	v.window.SetExitOnClose(false)
@@ -221,15 +252,23 @@ func (v *walkMainView) create() error {
 		}
 	})
 
-	return v.createTray()
+	return nil
 }
 
 func (v *walkMainView) createTray() error {
-	tray, err := walk.NewNotifyIcon()
+	tray, err := walk.NewNotifyIconWithGUID(ctyunHelperTrayGUID)
 	if err != nil {
 		return fmt.Errorf("创建系统托盘: %w", err)
 	}
 	v.tray = tray
+	ready := false
+	defer func() {
+		if ready {
+			return
+		}
+		tray.Dispose()
+		v.tray = nil
+	}()
 	if icon, err := walk.NewIconFromResourceId(1); err == nil {
 		_ = tray.SetIcon(icon)
 	} else {
@@ -288,6 +327,7 @@ func (v *walkMainView) createTray() error {
 	if err := tray.SetVisible(true); err != nil {
 		return fmt.Errorf("显示系统托盘: %w", err)
 	}
+	ready = true
 	return nil
 }
 

--- a/internal/winui/walk_main_windows_test.go
+++ b/internal/winui/walk_main_windows_test.go
@@ -1,0 +1,27 @@
+//go:build windows
+
+package winui
+
+import "testing"
+
+func TestShouldShowMainWindow(t *testing.T) {
+	tests := []struct {
+		name          string
+		startHidden   bool
+		trayAvailable bool
+		want          bool
+	}{
+		{name: "normal launch with tray", startHidden: false, trayAvailable: true, want: true},
+		{name: "startup launch with tray", startHidden: true, trayAvailable: true, want: false},
+		{name: "normal launch without tray", startHidden: false, trayAvailable: false, want: true},
+		{name: "startup launch without tray", startHidden: true, trayAvailable: false, want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldShowMainWindow(tt.startHidden, tt.trayAvailable); got != tt.want {
+				t.Fatalf("shouldShowMainWindow(%v, %v) = %v, want %v", tt.startHidden, tt.trayAvailable, got, tt.want)
+			}
+		})
+	}
+}

--- a/scripts/build-release-windows.ps1
+++ b/scripts/build-release-windows.ps1
@@ -1,0 +1,56 @@
+[CmdletBinding()]
+param(
+    [string]$Version,
+    [string]$OutputDirectory
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$repositoryRoot = (Resolve-Path (Join-Path $PSScriptRoot '..')).Path
+if ([string]::IsNullOrWhiteSpace($OutputDirectory)) {
+    $OutputDirectory = Join-Path $repositoryRoot 'dist'
+}
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $buildInfoPath = Join-Path $repositoryRoot 'internal\buildinfo\info.go'
+    $buildInfo = [System.IO.File]::ReadAllText($buildInfoPath)
+    $match = [regex]::Match($buildInfo, 'var\s+Version\s*=\s*"([^"]+)"')
+    if (-not $match.Success) {
+        throw "Cannot read version from $buildInfoPath"
+    }
+    $Version = $match.Groups[1].Value
+}
+
+$Version = $Version.Trim()
+if ($Version.StartsWith('v', [StringComparison]::OrdinalIgnoreCase)) {
+    $Version = $Version.Substring(1)
+}
+if ($Version -notmatch '^\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)?$') {
+    throw "Invalid release version: $Version"
+}
+
+New-Item -ItemType Directory -Force -Path $OutputDirectory | Out-Null
+$outputPath = Join-Path $OutputDirectory "CtyunHelper-v$Version.exe"
+$ldflags = "-H=windowsgui -X github.com/uvwt/CtyunHelper/internal/buildinfo.Version=$Version"
+
+Push-Location $repositoryRoot
+try {
+    & go build -ldflags $ldflags -o $outputPath ./cmd/ctyun-helper
+    if ($LASTEXITCODE -ne 0) {
+        throw "go build failed with exit code $LASTEXITCODE"
+    }
+
+    & (Join-Path $PSScriptRoot 'embed-icon-windows.ps1') -Executable $outputPath
+    if ($LASTEXITCODE -ne 0) {
+        throw "embedding Windows resources failed with exit code $LASTEXITCODE"
+    }
+}
+finally {
+    Pop-Location
+}
+
+$hash = Get-FileHash -Algorithm SHA256 -Path $outputPath
+Write-Host "Built release asset: $outputPath"
+Write-Host "SHA256: $($hash.Hash)"
+Write-Output $outputPath


### PR DESCRIPTION
## 变更
- 使用固定 GUID 注册系统托盘，规避 Walk 普通 `(HWND, ID)` 托盘路径在部分 Windows Shell 环境下的 `Shell_NotifyIcon(NIM_ADD)` 失败
- 托盘初始化失败时降级为普通窗口模式，不再阻止 Runtime、保活和自动任务启动
- 增加托盘不可用时的窗口显示策略测试
- 新增 Windows Release 构建脚本，产物统一为 `CtyunHelper-v<版本号>.exe`
- 同步 README 的下载与构建说明

## 验证
- `go test ./...`
- `go vet ./...`
- 发布构建成功：`dist/CtyunHelper-v0.1.3.exe`
- Windows 实机验证固定 GUID 托盘注册：`Shell_NotifyIconGetRect = 0x00000000`
- 二次启动单实例行为正常

Fixes #4