### PR TITLE
chore: bump version to 0.1.4

### DIFF
--- a/internal/buildinfo/info.go
+++ b/internal/buildinfo/info.go
@@ -9,4 +9,4 @@ const (
 
 // Version 是唯一的应用版本来源。正式发布可继续通过 -ldflags -X 覆盖，
 // 便于后续版本构建时保持 UI 与发布元数据一致。
-var Version = "0.1.3"
+var Version = "0.1.4"


### PR DESCRIPTION
## Summary
- bump CtyunHelper application version to 0.1.4

## Verification
- go test ./...
- go vet ./...
- Windows release build succeeded
- built EXE metadata reports buildinfo.Version=0.1.4
- Windows GUI starts successfully